### PR TITLE
fix: update docker volumn path

### DIFF
--- a/package/screwdriver_cd_setup/__init__.py
+++ b/package/screwdriver_cd_setup/__init__.py
@@ -28,7 +28,7 @@ services:
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock:rw
             - ./data/:/tmp/sd-data/:rw
-            - ./local.yaml:/usr/src/app/node_modules/screwdriver-cd-api/config/local.yaml
+            - ./local.yaml:/usr/src/app/node_modules/screwdriver-api/config/local.yaml
         environment:
             PORT: 80
             URI: http://${ip}:9001


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed
修复docker volumn映射的路径问题
### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
